### PR TITLE
Validation にemailとpasswordの日本語訳を追加

### DIFF
--- a/lang/ja/validation.php
+++ b/lang/ja/validation.php
@@ -185,6 +185,8 @@ return [
         'description' => '商品説明',
         'price' => '値段',
         'img_src' => '画像登録',
+        "email" => 'メールアドレス',
+        "password" => 'パスワード',
     ],
 
 ];


### PR DESCRIPTION
会員登録に未記入のときのエラーメッセージのために追加しました。
確認をお願いします。